### PR TITLE
latest changes

### DIFF
--- a/nix/modules/nixos/services/web/paperless/default.nix
+++ b/nix/modules/nixos/services/web/paperless/default.nix
@@ -24,6 +24,7 @@ in
       address = "127.0.0.1";
       passwordFile = config.sops.secrets.paperless-admin-password.path;
       settings.PAPERLESS_ADMIN_USER = "ndumazet";
+      settings.PAPERLESS_URL = "https://paperless.home.nicdumz.fr";
     };
 
     sops.secrets.paperless-admin-password = {

--- a/nix/modules/nixos/system/boot/default.nix
+++ b/nix/modules/nixos/system/boot/default.nix
@@ -28,7 +28,7 @@
       grub.enable = false;
       systemd-boot = {
         enable = true;
-        configurationLimit = 10;
+        configurationLimit = 7;
         editor = false;
         # highlight last booted
         extraInstallCommands = ''


### PR DESCRIPTION
- **Upgrade to 25.05**
- **A few less versions to limit `/boot` size**
- **set paperless URL (https://docs.paperless-ngx.com/configuration/#PAPERLESS_URL)**
