### PR TITLE
ci: enforce conventional commit standards in Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,3 +25,11 @@ queue_rules:
           - check-success = All Garnix checks
 merge_protections_settings:
   reporting_method: check-runs
+merge_protections:
+  # Commit Standards
+  - name: Enforce conventional commit
+    description: Make sure that we follow https://www.conventionalcommits.org/en/v1.0.0/
+    if:
+      - base = main
+    success_conditions:
+      - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"


### PR DESCRIPTION
Added merge protection for conventional commits on main branch.