### PR TITLE
feat: gnome-keyring integration and work module for lethargyfamily

### DIFF
--- a/nix/modules/home/apps/graphical/default.nix
+++ b/nix/modules/home/apps/graphical/default.nix
@@ -52,6 +52,7 @@ in
     };
     services = {
       hyprpolkitagent.enable = true;
+      gnome-keyring.enable = true;
 
       # auto-lock
       hypridle = {

--- a/nix/modules/nixos/apps/graphical/default.nix
+++ b/nix/modules/nixos/apps/graphical/default.nix
@@ -23,6 +23,12 @@
       # Allows remembering the last logged in user.
       accounts-daemon.enable = true;
       # udev.packages = [ pkgs.gnome-settings-daemon ];
+      gnome.gnome-keyring.enable = true;
+    };
+
+    security.pam.services = {
+      sddm.enableGnomeKeyring = true;
+      hyprlock.enableGnomeKeyring = true;
     };
 
     ${namespace} = {

--- a/nix/systems/x86_64-linux/lethargyfamily/default.nix
+++ b/nix/systems/x86_64-linux/lethargyfamily/default.nix
@@ -25,5 +25,6 @@
       defaultFontSize = 14;
       factor = 0.8;
     };
+    work.enable = true;
   };
 }


### PR DESCRIPTION
## Summary

- Enable gnome-keyring service in home-manager (hyprland/graphical profile)
- Enable gnome-keyring at the NixOS system level and wire up PAM for sddm and hyprlock so the keyring unlocks on login
- Enable the `work` module on the `lethargyfamily` system

## Test plan

- [ ] Build and switch on `lethargyfamily`
- [ ] Verify gnome-keyring unlocks automatically at login via sddm
- [ ] Verify hyprlock re-unlocks keyring on screen unlock
- [ ] Verify work-related apps/config are active on lethargyfamily

🤖 Generated with [Claude Code](https://claude.com/claude-code)